### PR TITLE
docs: warn against merging quantized fine-tuned weights

### DIFF
--- a/docs/en/docs/deploy/hardware.md
+++ b/docs/en/docs/deploy/hardware.md
@@ -22,6 +22,10 @@ The following table lists the estimated video memory requirements for different 
 
 If you wish to enable the QLoRA fine-tuning method, please refer to the subsequent chapter "[Enable QLoRA (Optional Configuration)](model_finetuning.md#enable-qlora-optional-configuration)" to learn how to switch the fine-tuning strategy.
 
+> [!Warning]
+> 
+> The weights fine-tuned using the quantized model cannot be merged back into the original model.
+
 ::: tip
 Video Memory ≥16GB: The default LoRA fine-tuning scheme is recommended.
 Video Memory <16GB: Consider switching to QLoRA or choosing a model with a smaller number of parameters.

--- a/docs/en/docs/deploy/model_finetuning.md
+++ b/docs/en/docs/deploy/model_finetuning.md
@@ -40,6 +40,10 @@ After the training is complete, the fine-tuned LoRA adapter weights will be save
 
 If you want to further reduce video memory consumption, you can enable **QLoRA quantized training**.
 
+> [!Warning]
+> 
+> The weights fine-tuned using the quantized model cannot be merged back into the original model.
+
 Add the following configuration to the `common_args` field in `settings.jsonc`:
 
 ```json

--- a/docs/en/docs/introduce/FAQ.md
+++ b/docs/en/docs/introduce/FAQ.md
@@ -16,7 +16,8 @@ If the problem is not resolved, please raise it in [Issues](https://github.com/x
     2. Reduce the maximum sequence length: `cutoff_len: 512`
     3. Replace model operators: `enable_liger_kernel: true` and `use_unsloth_gc: true`
     4. Use DeepSpeed ZeRO-3 or FSDP to split model weights across multiple devices or use CPU Offloading
-    5. Set `quantization_bit: 4` to quantize model parameters (only for the LoRA method)
+    5. Fine-tune with a quantized model (weights cannot be merged into the original model)
+    6. Set `quantization_bit: 4` to quantize model parameters (only for the LoRA method)
 - You can first rent a GPU on an online cloud platform for fine-tuning, then download the fine-tuned `model_output` folder to your local machine for deployment and inference.
 - For multimodal models, reduce `image_max_pixels` and `max_image_num`.
 ---

--- a/docs/zh/docs/deploy/hardware.md
+++ b/docs/zh/docs/deploy/hardware.md
@@ -22,6 +22,10 @@ pageClass: wide-page
 
 如果你希望启用 QLoRA 微调方式，请查阅后续章节 “[启用 QLoRA（可选配置）](model_finetuning.md#启用-qlora-可选配置)” 了解如何切换微调策略。
 
+> [!Warning]
+> 
+> 使用量化后的模型进行微调后权重将无法合并到原模型中。
+
 ::: tip
 显存 ≥16GB：推荐使用默认的 LoRA 微调方案。    
 显存 <16GB：可考虑切换至 QLoRA 或选择更小参数量的模型。

--- a/docs/zh/docs/deploy/model_finetuning.md
+++ b/docs/zh/docs/deploy/model_finetuning.md
@@ -40,6 +40,11 @@ weclone-cli train-sft
 
 如果你希望进一步减少显存消耗，可以开启 **QLoRA 量化训练**。
 
+> [!Warning]
+> 
+> 使用量化后的模型进行微调后权重将无法合并到原模型中。
+
+
 在 `settings.jsonc` 的 `common_args` 字段中添加以下配置：
 
 ```json

--- a/docs/zh/docs/introduce/FAQ.md
+++ b/docs/zh/docs/introduce/FAQ.md
@@ -16,7 +16,8 @@
     2. 降低最大序列长度 cutoff_len: 512
     3. 替换模型算子 enable_liger_kernel: true 和 use_unsloth_gc: true
     4. 使用 DeepSpeed ZeRO-3 或 FSDP 将模型权重拆分到多个设备或使用 CPU Offloading
-    5. 设置 quantization_bit: 4 量化模型参数（仅限于 LoRA 方法）
+    5. 使用量化后的模型微调（权重无法合并到原模型中）
+    6. 设置 quantization_bit: 4 量化模型参数（仅限于 LoRA 方法）
 - 可以先租用在线云平台的GPU进行微调，再将微调后的model_output文件夹下载到本地，在本地部署推理。
 - 多模态模型减少`image_max_pixels`和`max_image_num`。
 ---


### PR DESCRIPTION
Adds a warning to the documentation regarding the inability
to merge weights fine-tuned using quantized models back into
the original model. This clarifies the limitations of QLoRA
fine-tuning for users in both English and Chinese documentation.