### PR TITLE
docs: adds FAQ for Windows environment

### DIFF
--- a/docs/en/docs/introduce/FAQ.md
+++ b/docs/en/docs/introduce/FAQ.md
@@ -36,3 +36,6 @@ If the problem is not resolved, please raise it in [Issues](https://github.com/x
 
 ### The chat history CSV file opens with garbled characters
 Do not use Excel to open it. Use an IDE such as VS Code.
+
+### Windows Environment Issues
+- Set the `"dataloader_num_workers": 0` parameter in `train_sft_args` to solve the `Can't pickle local object` problem in the Windows environment.

--- a/docs/zh/docs/introduce/FAQ.md
+++ b/docs/zh/docs/introduce/FAQ.md
@@ -36,3 +36,6 @@
 
 ### 聊天记录CSV文件打开乱码
 不要使用Excel打开，使用IDE例如vscode打开。
+
+### Windows环境问题
+- `train_sft_args` 中设置`"dataloader_num_workers": 0` 参数，来解决Windows环境下 `Can't pickle local object` 的问题。


### PR DESCRIPTION
Adds a FAQ entry about setting `dataloader_num_workers` to 0
in `train_sft_args` to address the `Can't pickle local object`
error on Windows.